### PR TITLE
Fix mixed content errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,11 +38,11 @@
       </ul>
     </p>
     <p>Remember to <a href="http://www.mailgun.com">sign up for Mailgun</a> to receive your public API key.</p>
-    <p><iframe src="http://ghbtns.com/github-btn.html?user=mailgun&repo=validator-demo&type=watch&size=large&count=true"
-  allowtransparency="true" frameborder="0" scrolling="0"></iframe> <iframe src="http://ghbtns.com/github-btn.html?user=mailgun&repo=validator-demo&type=fork&size=large&count=true"
+    <p><iframe src="//ghbtns.com/github-btn.html?user=mailgun&repo=validator-demo&type=watch&size=large&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0"></iframe> <iframe src="//ghbtns.com/github-btn.html?user=mailgun&repo=validator-demo&type=fork&size=large&count=true"
   allowtransparency="true" frameborder="0" scrolling="0"></iframe></p>
 
-    <script src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
+    <script src="//code.jquery.com/jquery-1.10.1.min.js"></script>
     <script src="mailgun_validator.js"></script>
     <script>
       // document ready


### PR DESCRIPTION
Currently Firefox reports the following errors (Chrome reports similar errors):

> - Blocked loading mixed active content "http://code.jquery.com/jquery-1.10.1.min.js"[Learn More] validator-demo
> - Blocked loading mixed active content "http://ghbtns.com/github-btn.html?user=mailgun&repo=validator-demo&type=watch&size=large&count=true"[Learn More] validator-demo
> - Blocked loading mixed active content "http://ghbtns.com/github-btn.html?user=mailgun&repo=validator-demo&type=fork&size=large&count=true"[Learn More] validator-demo
> - ReferenceError: $ is not defined mailgun_validator.js:31:0
> - ReferenceError: $ is not defined validator-demo:49:6

Using `//` instead of `http://` lets the browser inherit the protocol from the main page. Alternatively, you could specify `https://`.
